### PR TITLE
BAU: Remove Germany from dev config for now.

### DIFF
--- a/dev-metadata.yml
+++ b/dev-metadata.yml
@@ -2,5 +2,3 @@ CEF Proxy Node:
   url: https://cef-proxy-node-eidas-joint.cloudapps.digital/ServiceMetadata
 Stub Country:
   url: https://ida-stub-idp-joint.cloudapps.digital/stub-country/ServiceMetadata
-German Middleware:
-  url: https://18.130.232.23:8443/eidas-middleware/Metadata


### PR DESCRIPTION
The auto-fetch Jenkins job doesn't like the self signed cert. So I'm temporarily removing Germany middleware config. 

The file will be manually uploaded to the S3 bucket for now.