### PR TITLE
EID-827 Healthcheck to output most recent aggregation results.

### DIFF
--- a/src/main/java/uk/gov/ida/metadataaggregator/MetadataAggregatorApplication.java
+++ b/src/main/java/uk/gov/ida/metadataaggregator/MetadataAggregatorApplication.java
@@ -6,6 +6,7 @@ import com.squarespace.jersey2.guice.JerseyGuiceUtils;
 import io.dropwizard.Application;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
+import uk.gov.ida.metadataaggregator.healthcheck.AggregationStatusHealthCheck;
 import uk.gov.ida.metadataaggregator.managed.ScheduledMetadataAggregator;
 
 public class MetadataAggregatorApplication extends Application<MetadataAggregatorConfiguration> {
@@ -39,5 +40,6 @@ public class MetadataAggregatorApplication extends Application<MetadataAggregato
     public final void run(MetadataAggregatorConfiguration configuration, Environment environment) {
         environment.getObjectMapper().setDateFormat(StdDateFormat.getDateInstance());
         environment.lifecycle().manage(guiceBundle.getInjector().getInstance(ScheduledMetadataAggregator.class));
+        environment.healthChecks().register("lastAggregation", guiceBundle.getInjector().getInstance(AggregationStatusHealthCheck.class));
     }
 }

--- a/src/main/java/uk/gov/ida/metadataaggregator/MetadataAggregatorModule.java
+++ b/src/main/java/uk/gov/ida/metadataaggregator/MetadataAggregatorModule.java
@@ -10,6 +10,7 @@ import com.google.inject.name.Named;
 import uk.gov.ida.metadataaggregator.configuration.MetadataSourceConfiguration;
 import uk.gov.ida.metadataaggregator.configuration.MetadataSourceConfigurationLoader;
 import uk.gov.ida.metadataaggregator.core.S3BucketMetadataStore;
+import uk.gov.ida.metadataaggregator.core.StatusReport;
 import uk.gov.ida.metadataaggregator.exceptions.ConfigSourceException;
 import uk.gov.ida.metadataaggregator.managed.MetadataAggregationTaskRunner;
 import uk.gov.ida.metadataaggregator.managed.ScheduledMetadataAggregator;
@@ -20,6 +21,7 @@ import java.net.URI;
 import java.security.KeyStore;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
 
 class MetadataAggregatorModule extends AbstractModule {
 
@@ -85,5 +87,11 @@ class MetadataAggregatorModule extends AbstractModule {
     @Named("BlockingExecutor")
     public ScheduledExecutorService getScheduledExecutorService(){
         return Executors.newSingleThreadScheduledExecutor();
+    }
+
+    @Provides
+    @Singleton
+    public AtomicReference<StatusReport> getStatusReportReference() {
+        return new AtomicReference<>();
     }
 }

--- a/src/main/java/uk/gov/ida/metadataaggregator/MetadataAggregatorModule.java
+++ b/src/main/java/uk/gov/ida/metadataaggregator/MetadataAggregatorModule.java
@@ -12,6 +12,7 @@ import uk.gov.ida.metadataaggregator.configuration.MetadataSourceConfigurationLo
 import uk.gov.ida.metadataaggregator.core.S3BucketMetadataStore;
 import uk.gov.ida.metadataaggregator.core.StatusReport;
 import uk.gov.ida.metadataaggregator.exceptions.ConfigSourceException;
+import uk.gov.ida.metadataaggregator.healthcheck.AggregationStatusHealthCheck;
 import uk.gov.ida.metadataaggregator.managed.MetadataAggregationTaskRunner;
 import uk.gov.ida.metadataaggregator.managed.ScheduledMetadataAggregator;
 import uk.gov.ida.saml.metadata.EidasTrustAnchorResolver;
@@ -29,6 +30,7 @@ class MetadataAggregatorModule extends AbstractModule {
     protected void configure() {
         bind(ScheduledMetadataAggregator.class);
         bind(MetadataAggregationTaskRunner.class);
+        bind(AggregationStatusHealthCheck.class);
     }
 
     @Provides

--- a/src/main/java/uk/gov/ida/metadataaggregator/core/MetadataAggregator.java
+++ b/src/main/java/uk/gov/ida/metadataaggregator/core/MetadataAggregator.java
@@ -32,7 +32,7 @@ public class MetadataAggregator {
     public StatusReport aggregateMetadata() {
         LOGGER.info("Processing country metadatasource");
 
-        StatusReport report = new StatusReport(configuration.getMetadataUrls());
+        StatusReport report = new StatusReport(configuration.getMetadataUrls().size());
         Collection<URL> configMetadataUrls = configuration.getMetadataUrls().values();
 
         deleteMetadataWhichIsNotInConfig(configMetadataUrls);

--- a/src/main/java/uk/gov/ida/metadataaggregator/core/MetadataAggregator.java
+++ b/src/main/java/uk/gov/ida/metadataaggregator/core/MetadataAggregator.java
@@ -41,7 +41,7 @@ public class MetadataAggregator {
             try {
                 EntityDescriptor countryMetadataFile = countryMetadataResolver.downloadMetadata(metadataUrl);
                 s3BucketMetadataStore.uploadMetadata(HexUtils.encodeString(metadataUrl.toString()), countryMetadataFile);
-                report.recordSuccess(metadataUrl);
+                report.recordSuccess();
             } catch (MetadataSourceException | MetadataStoreException e) {
                 LOGGER.error("Error processing metadata {}", metadataUrl, e);
                 deleteMetadataWithHexEncodedMetadataUrl(HexUtils.encodeString(metadataUrl.toString()));

--- a/src/main/java/uk/gov/ida/metadataaggregator/core/StatusReport.java
+++ b/src/main/java/uk/gov/ida/metadataaggregator/core/StatusReport.java
@@ -24,7 +24,7 @@ public class StatusReport {
     return errorsFromMetadataUrl;
   }
 
-  public void recordSuccess(URL metadataUrl) {
+  public void recordSuccess() {
     numberOfSuccesses++;
   }
 

--- a/src/main/java/uk/gov/ida/metadataaggregator/core/StatusReport.java
+++ b/src/main/java/uk/gov/ida/metadataaggregator/core/StatusReport.java
@@ -12,8 +12,8 @@ public class StatusReport {
   private final int expectedSuccesses;
   private final HashMap<URL, Throwable> errorsFromMetadataUrl = new HashMap<URL, Throwable>();
 
-  public StatusReport(Map<String, URL> metadataUrlsFromNames) {
-    this.expectedSuccesses = metadataUrlsFromNames.size();
+  public StatusReport(int expectedSuccesses) {
+    this.expectedSuccesses = expectedSuccesses;
   }
 
   public DateTime getRunAt() {

--- a/src/main/java/uk/gov/ida/metadataaggregator/core/StatusReport.java
+++ b/src/main/java/uk/gov/ida/metadataaggregator/core/StatusReport.java
@@ -1,0 +1,42 @@
+package uk.gov.ida.metadataaggregator.core;
+
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.joda.time.DateTime;
+
+public class StatusReport {
+  private int numberOfSuccesses = 0;
+  private final DateTime runAt = DateTime.now();
+  private final int expectedSuccesses;
+  private final HashMap<URL, Throwable> errorsFromMetadataUrl = new HashMap<URL, Throwable>();
+
+  public StatusReport(Map<String, URL> metadataUrlsFromNames) {
+    this.expectedSuccesses = metadataUrlsFromNames.size();
+  }
+
+  public DateTime getRunAt() {
+    return runAt;
+  }
+
+  public Map<URL, Throwable> getErrors() {
+    return errorsFromMetadataUrl;
+  }
+
+  public void recordSuccess(URL metadataUrl) {
+    numberOfSuccesses++;
+  }
+
+  public void recordFailure(URL metadataUrl, Throwable result) {
+    errorsFromMetadataUrl.put(metadataUrl, result);
+  }
+
+  public boolean wasSuccessful() {
+    return numberOfSuccesses == expectedSuccesses;
+  }
+
+  public int numberOfSuccesses() {
+    return numberOfSuccesses;
+  }
+}

--- a/src/main/java/uk/gov/ida/metadataaggregator/healthcheck/AggregationStatusHealthCheck.java
+++ b/src/main/java/uk/gov/ida/metadataaggregator/healthcheck/AggregationStatusHealthCheck.java
@@ -17,7 +17,7 @@ public class AggregationStatusHealthCheck extends HealthCheck {
     }
 
     @Override
-    public Result check() throws Exception {
+    public Result check() {
         StatusReport report = lastReportRef.get();
         if (report == null) return Result.unhealthy("No refresh has been run yet");
         ResultBuilder healthCheckResult = report.wasSuccessful() ?

--- a/src/main/java/uk/gov/ida/metadataaggregator/healthcheck/AggregationStatusHealthCheck.java
+++ b/src/main/java/uk/gov/ida/metadataaggregator/healthcheck/AggregationStatusHealthCheck.java
@@ -1,0 +1,31 @@
+package uk.gov.ida.metadataaggregator.healthcheck;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.codahale.metrics.health.HealthCheck;
+import com.google.inject.Inject;
+
+import uk.gov.ida.metadataaggregator.core.StatusReport;
+
+public class AggregationStatusHealthCheck extends HealthCheck {
+
+    private AtomicReference<StatusReport> lastReportRef;
+
+    @Inject
+    public AggregationStatusHealthCheck(AtomicReference<StatusReport> lastReportRef) {
+        this.lastReportRef = lastReportRef;
+    }
+
+    @Override
+    public Result check() throws Exception {
+        StatusReport report = lastReportRef.get();
+        if (report == null) return Result.unhealthy("No refresh has been run yet");
+        ResultBuilder healthCheckResult = report.wasSuccessful() ?
+            Result.builder().healthy() :
+            Result.builder().unhealthy();
+        return healthCheckResult
+            .withDetail("runAt", report.getRunAt())
+            .withDetail("errors", report.getErrors())
+            .build();
+    }
+}

--- a/src/main/java/uk/gov/ida/metadataaggregator/managed/MetadataAggregationTaskRunner.java
+++ b/src/main/java/uk/gov/ida/metadataaggregator/managed/MetadataAggregationTaskRunner.java
@@ -1,5 +1,7 @@
 package uk.gov.ida.metadataaggregator.managed;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -7,6 +9,7 @@ import uk.gov.ida.metadataaggregator.configuration.MetadataSourceConfiguration;
 import uk.gov.ida.metadataaggregator.core.CountryMetadataResolver;
 import uk.gov.ida.metadataaggregator.core.MetadataAggregator;
 import uk.gov.ida.metadataaggregator.core.S3BucketMetadataStore;
+import uk.gov.ida.metadataaggregator.core.StatusReport;
 import uk.gov.ida.saml.metadata.EidasTrustAnchorResolver;
 
 // Wraps all of the dependencies required to run metadata aggregations.
@@ -16,14 +19,17 @@ public class MetadataAggregationTaskRunner implements Runnable{
     private final MetadataSourceConfiguration configSource;
     private final S3BucketMetadataStore metadataStore;
     private final EidasTrustAnchorResolver eidasTrustAnchorResolver;
+    private final AtomicReference<StatusReport> statusReportRef;
 
     @Inject
     public MetadataAggregationTaskRunner(MetadataSourceConfiguration configSource,
                                          S3BucketMetadataStore metadataStore,
-                                         EidasTrustAnchorResolver eidasTrustAnchorResolver) {
+                                         EidasTrustAnchorResolver eidasTrustAnchorResolver,
+                                         AtomicReference<StatusReport> statusReportRef) {
         this.configSource = configSource;
         this.metadataStore = metadataStore;
         this.eidasTrustAnchorResolver = eidasTrustAnchorResolver;
+        this.statusReportRef = statusReportRef;
     }
 
     public void run() {
@@ -31,8 +37,9 @@ public class MetadataAggregationTaskRunner implements Runnable{
             log.info("Beginning metadata aggregation");
             CountryMetadataResolver countryMetadataSource = CountryMetadataResolver.fromTrustAnchor(eidasTrustAnchorResolver);
             MetadataAggregator metadataAggregator = new MetadataAggregator(configSource, countryMetadataSource, metadataStore);
-            boolean result = metadataAggregator.aggregateMetadata();
-            log.info("Completed metadata aggregation {}", result ? "successfully" : "unsuccessfully");
+            StatusReport result = metadataAggregator.aggregateMetadata();
+            log.info("Completed metadata aggregation {}", result.wasSuccessful() ? "successfully" : "unsuccessfully");
+            statusReportRef.set(result);
         } catch (Exception e) {
             log.error("Uncaught error during metadata aggregation", e);
         }

--- a/src/test/java/uk/gov/ida/metadataaggregator/AggregationStatusHealthCheckTest.java
+++ b/src/test/java/uk/gov/ida/metadataaggregator/AggregationStatusHealthCheckTest.java
@@ -43,21 +43,21 @@ public class AggregationStatusHealthCheckTest {
     }
 
     @Test
-    public void testHealthCheckStatusIsUnhealthyWhenFailuresReported() throws Exception {
+    public void testHealthCheckStatusIsUnhealthyWhenFailuresReported() {
         when(statusReport.wasSuccessful()).thenReturn(false);
         Result result = healthCheck.check();
         assertFalse(result.isHealthy());
     }
 
     @Test
-    public void testHealthCheckStatusIsHealthyWhenSuccessReported() throws Exception {
+    public void testHealthCheckStatusIsHealthyWhenSuccessReported() {
         when(statusReport.wasSuccessful()).thenReturn(true);
         Result result = healthCheck.check();
         assertTrue(result.isHealthy());
     }
 
     @Test
-    public void testHealthCheckContainsURLsOfFailingMetadata() throws Exception {
+    public void testHealthCheckContainsURLsOfFailingMetadata() {
         when(statusReport.wasSuccessful()).thenReturn(false);
         when(statusReport.getErrors()).thenReturn(metadataUrls);
         Result result = healthCheck.check();

--- a/src/test/java/uk/gov/ida/metadataaggregator/AggregationStatusHealthCheckTest.java
+++ b/src/test/java/uk/gov/ida/metadataaggregator/AggregationStatusHealthCheckTest.java
@@ -1,0 +1,74 @@
+package uk.gov.ida.metadataaggregator;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.codahale.metrics.health.HealthCheck.Result;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.when;
+
+import uk.gov.ida.metadataaggregator.core.StatusReport;
+import uk.gov.ida.metadataaggregator.healthcheck.AggregationStatusHealthCheck;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AggregationStatusHealthCheckTest {
+    @Mock
+    private StatusReport statusReport;
+
+    private URL metadataUrl;
+    private Map<URL, Throwable> metadataUrls;
+    private AtomicReference<StatusReport> reportRef;
+    private AggregationStatusHealthCheck healthCheck;
+
+    @Before
+    public void setUp() throws MalformedURLException {
+        metadataUrl = new URL("https://localhost:80/");
+        metadataUrls = new HashMap<>();
+        metadataUrls.put(metadataUrl, new RuntimeException("test"));
+        reportRef = new AtomicReference<StatusReport>();
+        reportRef.set(statusReport);
+        healthCheck = new AggregationStatusHealthCheck(reportRef);
+    }
+
+    @Test
+    public void testHealthCheckStatusIsUnhealthyWhenFailuresReported() throws Exception {
+        when(statusReport.wasSuccessful()).thenReturn(false);
+        Result result = healthCheck.check();
+        assertFalse(result.isHealthy());
+    }
+
+    @Test
+    public void testHealthCheckStatusIsHealthyWhenSuccessReported() throws Exception {
+        when(statusReport.wasSuccessful()).thenReturn(true);
+        Result result = healthCheck.check();
+        assertTrue(result.isHealthy());
+    }
+
+    @Test
+    public void testHealthCheckContainsURLsOfFailingMetadata() throws Exception {
+        when(statusReport.wasSuccessful()).thenReturn(false);
+        when(statusReport.getErrors()).thenReturn(metadataUrls);
+        Result result = healthCheck.check();
+        assertTrue(result.getDetails().containsKey("errors"));
+        assertTrue(((Map<URL, Throwable>) result.getDetails().get("errors")).containsKey(metadataUrl));
+    }
+
+    @Test
+    public void testHealthCheckWithNoReportIsUnhealthy() throws Exception {
+        reportRef.set(null);
+        Result result = healthCheck.check();
+        assertFalse(result.isHealthy());
+    }
+}

--- a/src/test/java/uk/gov/ida/metadataaggregator/StatusReportTest.java
+++ b/src/test/java/uk/gov/ida/metadataaggregator/StatusReportTest.java
@@ -1,0 +1,43 @@
+package uk.gov.ida.metadataaggregator;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashMap;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import uk.gov.ida.metadataaggregator.core.StatusReport;
+
+public class StatusReportTest {
+  private URL metadataUrl;
+  private HashMap<String, URL> metadataUrls;
+
+  @Before
+  public void setUp() throws MalformedURLException {
+    metadataUrl = new URL("http://localhost:80");
+    metadataUrls = new HashMap<>();
+  }
+
+  @Test
+  public void testOnlySuccessfulWhenAllMetadataProcessed() throws MalformedURLException {
+    metadataUrls.put("local", metadataUrl);
+    StatusReport report = new StatusReport(metadataUrls);
+
+    assertFalse(report.wasSuccessful());
+    report.recordSuccess(metadataUrl);
+    assertTrue(report.wasSuccessful());
+  }
+
+  @Test
+  public void testUnsuccessfulWhenMetadataFails() {
+    metadataUrls.put("local", metadataUrl);
+    StatusReport report = new StatusReport(metadataUrls);
+
+    report.recordFailure(metadataUrl, new Exception());
+    assertFalse(report.wasSuccessful());
+  }
+}

--- a/src/test/java/uk/gov/ida/metadataaggregator/StatusReportTest.java
+++ b/src/test/java/uk/gov/ida/metadataaggregator/StatusReportTest.java
@@ -24,8 +24,7 @@ public class StatusReportTest {
 
   @Test
   public void testOnlySuccessfulWhenAllMetadataProcessed() throws MalformedURLException {
-    metadataUrls.put("local", metadataUrl);
-    StatusReport report = new StatusReport(metadataUrls);
+    StatusReport report = new StatusReport(1);
 
     assertFalse(report.wasSuccessful());
     report.recordSuccess(metadataUrl);
@@ -34,8 +33,7 @@ public class StatusReportTest {
 
   @Test
   public void testUnsuccessfulWhenMetadataFails() {
-    metadataUrls.put("local", metadataUrl);
-    StatusReport report = new StatusReport(metadataUrls);
+    StatusReport report = new StatusReport(1);
 
     report.recordFailure(metadataUrl, new Exception());
     assertFalse(report.wasSuccessful());

--- a/src/test/java/uk/gov/ida/metadataaggregator/StatusReportTest.java
+++ b/src/test/java/uk/gov/ida/metadataaggregator/StatusReportTest.java
@@ -23,11 +23,11 @@ public class StatusReportTest {
   }
 
   @Test
-  public void testOnlySuccessfulWhenAllMetadataProcessed() throws MalformedURLException {
+  public void testOnlySuccessfulWhenAllMetadataProcessed() {
     StatusReport report = new StatusReport(1);
 
     assertFalse(report.wasSuccessful());
-    report.recordSuccess(metadataUrl);
+    report.recordSuccess();
     assertTrue(report.wasSuccessful());
   }
 


### PR DESCRIPTION
We now have a `/healthcheck` endpoint (from the Dropwizard framework) that will include a `lastRun` key. If the status of the healthcheck is `healthy`, then the last aggreation downloaded and uploaded successfully. If not, details of the metadata URLs that failed are also outputted.