### PR TITLE
EID-827 - Add Reconciliation Health Check

### DIFF
--- a/src/main/java/uk/gov/ida/metadataaggregator/MetadataAggregatorApplication.java
+++ b/src/main/java/uk/gov/ida/metadataaggregator/MetadataAggregatorApplication.java
@@ -7,6 +7,7 @@ import io.dropwizard.Application;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import uk.gov.ida.metadataaggregator.healthcheck.AggregationStatusHealthCheck;
+import uk.gov.ida.metadataaggregator.healthcheck.ReconciliationHealthCheck;
 import uk.gov.ida.metadataaggregator.managed.ScheduledMetadataAggregator;
 
 public class MetadataAggregatorApplication extends Application<MetadataAggregatorConfiguration> {
@@ -41,5 +42,6 @@ public class MetadataAggregatorApplication extends Application<MetadataAggregato
         environment.getObjectMapper().setDateFormat(StdDateFormat.getDateInstance());
         environment.lifecycle().manage(guiceBundle.getInjector().getInstance(ScheduledMetadataAggregator.class));
         environment.healthChecks().register("lastAggregation", guiceBundle.getInjector().getInstance(AggregationStatusHealthCheck.class));
+        environment.healthChecks().register("lastReconciliation", guiceBundle.getInjector().getInstance(ReconciliationHealthCheck.class));
     }
 }

--- a/src/main/java/uk/gov/ida/metadataaggregator/MetadataAggregatorModule.java
+++ b/src/main/java/uk/gov/ida/metadataaggregator/MetadataAggregatorModule.java
@@ -13,6 +13,7 @@ import uk.gov.ida.metadataaggregator.core.S3BucketMetadataStore;
 import uk.gov.ida.metadataaggregator.core.StatusReport;
 import uk.gov.ida.metadataaggregator.exceptions.ConfigSourceException;
 import uk.gov.ida.metadataaggregator.healthcheck.AggregationStatusHealthCheck;
+import uk.gov.ida.metadataaggregator.healthcheck.ReconciliationHealthCheck;
 import uk.gov.ida.metadataaggregator.managed.MetadataAggregationTaskRunner;
 import uk.gov.ida.metadataaggregator.managed.ScheduledMetadataAggregator;
 import uk.gov.ida.saml.metadata.EidasTrustAnchorResolver;
@@ -31,6 +32,7 @@ class MetadataAggregatorModule extends AbstractModule {
         bind(ScheduledMetadataAggregator.class);
         bind(MetadataAggregationTaskRunner.class);
         bind(AggregationStatusHealthCheck.class);
+        bind(ReconciliationHealthCheck.class);
     }
 
     @Provides

--- a/src/main/java/uk/gov/ida/metadataaggregator/healthcheck/ReconciliationHealthCheck.java
+++ b/src/main/java/uk/gov/ida/metadataaggregator/healthcheck/ReconciliationHealthCheck.java
@@ -1,0 +1,56 @@
+package uk.gov.ida.metadataaggregator.healthcheck;
+
+import com.codahale.metrics.health.HealthCheck;
+import uk.gov.ida.metadataaggregator.configuration.MetadataSourceConfiguration;
+import uk.gov.ida.metadataaggregator.core.S3BucketMetadataStore;
+import uk.gov.ida.metadataaggregator.exceptions.MetadataStoreException;
+import uk.gov.ida.metadataaggregator.util.HexUtils;
+
+import javax.inject.Inject;
+import java.net.URL;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.stream.Collectors;
+
+public class ReconciliationHealthCheck extends HealthCheck {
+
+    private final S3BucketMetadataStore metadataStore;
+    private final MetadataSourceConfiguration config;
+
+    @Inject
+    public ReconciliationHealthCheck(S3BucketMetadataStore metadataStore, MetadataSourceConfiguration config) {
+        this.metadataStore = metadataStore;
+        this.config = config;
+    }
+
+    @Override
+    public Result check() throws MetadataStoreException {
+        HashSet<String> fileUrlsInBucket = new HashSet<String>(metadataStore.getAllHexEncodedUrlsFromS3Bucket());
+        HashSet<String> inBucketNotInConfig = new HashSet<String>(fileUrlsInBucket);
+
+        HashSet<String> filesUrlsInConfig = getHexEncodeConfigUrls();
+        HashSet<String> inConfigNotInBucket = new HashSet<String>(filesUrlsInConfig);
+
+        inConfigNotInBucket.removeAll(fileUrlsInBucket);
+        inBucketNotInConfig.removeAll(filesUrlsInConfig);
+
+        if (!inConfigNotInBucket.isEmpty() || !inBucketNotInConfig.isEmpty()) {
+            return Result.builder().unhealthy()
+                    .withDetail("inConfigNotInBucket", inConfigNotInBucket)
+                    .withDetail("inBucketNotInConfig", inBucketNotInConfig)
+                    .build();
+        } else {
+            return Result.healthy();
+        }
+    }
+
+    private HashSet<String> getHexEncodeConfigUrls() {
+        Collection<String> filesInConfig = config.getMetadataUrls().values().stream().map(URL::toString).collect(Collectors.toSet());
+        HashSet<String> hexedConfigUrls = new HashSet<>();
+
+        for (String configMetadataUrl : filesInConfig) {
+            hexedConfigUrls.add(HexUtils.encodeString(configMetadataUrl));
+        }
+        return hexedConfigUrls;
+    }
+}

--- a/src/test/java/uk/gov/ida/metadataaggregator/ReconciliationHealthCheckTest.java
+++ b/src/test/java/uk/gov/ida/metadataaggregator/ReconciliationHealthCheckTest.java
@@ -1,0 +1,101 @@
+package uk.gov.ida.metadataaggregator;
+
+import com.codahale.metrics.health.HealthCheck;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.ida.metadataaggregator.configuration.MetadataSourceConfiguration;
+import uk.gov.ida.metadataaggregator.core.S3BucketMetadataStore;
+import uk.gov.ida.metadataaggregator.exceptions.MetadataStoreException;
+import uk.gov.ida.metadataaggregator.healthcheck.ReconciliationHealthCheck;
+import uk.gov.ida.metadataaggregator.util.HexUtils;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.HashMap;
+
+import static java.util.Collections.emptyList;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ReconciliationHealthCheckTest {
+
+    private ReconciliationHealthCheck reconciliationHealthCheck;
+    private final S3BucketMetadataStore metadataStore = mock(S3BucketMetadataStore.class);
+    private final MetadataSourceConfiguration config = mock(MetadataSourceConfiguration.class);
+    private final static String BUCKET_URL_A = HexUtils.encodeString("http://localhost-country-a");
+    private final static String BUCKET_URL_C = HexUtils.encodeString("http://localhost-country-c");
+    private URL countryAConfigUrl;
+    private URL countryBConfigUrl;
+    private HashMap<String, URL> configUrls;
+
+    @Before
+    public void setUp() throws MalformedURLException {
+        configUrls = new HashMap<>();
+        countryAConfigUrl = new URL("http://localhost-country-a");
+        countryBConfigUrl = new URL("http://localhost-country-b");
+        reconciliationHealthCheck = new ReconciliationHealthCheck(metadataStore, config);
+    }
+
+    @Test
+    public void shouldReturnHealthyWhenMetadataMatches() throws MetadataStoreException {
+        configUrls.put("someCountry", countryAConfigUrl);
+
+        when(config.getMetadataUrls()).thenReturn(configUrls);
+        when(metadataStore.getAllHexEncodedUrlsFromS3Bucket()).thenReturn(Arrays.asList(BUCKET_URL_A));
+
+        HealthCheck.Result check = reconciliationHealthCheck.check();
+
+        assertTrue(check.isHealthy());
+    }
+
+    @Test
+    public void shouldReturnHealthyWhenBothConfigAndBucketAreEmpty() throws MetadataStoreException {
+        when(config.getMetadataUrls()).thenReturn(configUrls);
+        when(metadataStore.getAllHexEncodedUrlsFromS3Bucket()).thenReturn(emptyList());
+
+        HealthCheck.Result check = reconciliationHealthCheck.check();
+
+        assertTrue(check.isHealthy());
+    }
+
+    @Test
+    public void shouldReturnUnhealthyWhenMetadataIsNotInBucket() throws MetadataStoreException {
+        configUrls.put("someCountry", countryAConfigUrl);
+
+        when(config.getMetadataUrls()).thenReturn(configUrls);
+        when(metadataStore.getAllHexEncodedUrlsFromS3Bucket()).thenReturn(emptyList());
+
+        HealthCheck.Result check = reconciliationHealthCheck.check();
+
+        assertFalse(check.isHealthy());
+    }
+
+    @Test
+    public void shouldReturnUnhealthyWhenMetadataIsNotInConfig() throws MetadataStoreException {
+        when(config.getMetadataUrls()).thenReturn(configUrls);
+        when(metadataStore.getAllHexEncodedUrlsFromS3Bucket()).thenReturn(Arrays.asList(BUCKET_URL_A));
+
+        HealthCheck.Result check = reconciliationHealthCheck.check();
+
+        assertFalse(check.isHealthy());
+    }
+
+    @Test
+    public void shouldReturnUnhealthyWhenMetadataIsNotInConfigOrNotInBucket() throws MetadataStoreException {
+        configUrls.put("countryA", countryAConfigUrl);
+        configUrls.put("countryB", countryBConfigUrl);
+
+        when(config.getMetadataUrls()).thenReturn(configUrls);
+        when(metadataStore.getAllHexEncodedUrlsFromS3Bucket()).thenReturn(Arrays.asList(BUCKET_URL_A,BUCKET_URL_C));
+
+        HealthCheck.Result check = reconciliationHealthCheck.check();
+
+        assertFalse(check.isHealthy());
+    }
+}

--- a/src/test/java/uk/gov/ida/metadataaggregator/ReconciliationHealthCheckTest.java
+++ b/src/test/java/uk/gov/ida/metadataaggregator/ReconciliationHealthCheckTest.java
@@ -15,9 +15,11 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Map;
 
 import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -32,7 +34,7 @@ public class ReconciliationHealthCheckTest {
     private final static String BUCKET_URL_C = HexUtils.encodeString("http://localhost-country-c");
     private URL countryAConfigUrl;
     private URL countryBConfigUrl;
-    private HashMap<String, URL> configUrls;
+    private Map <String, URL> configUrls;
 
     @Before
     public void setUp() throws MalformedURLException {
@@ -73,7 +75,11 @@ public class ReconciliationHealthCheckTest {
 
         HealthCheck.Result check = reconciliationHealthCheck.check();
 
+        String metadataConfigHealthCheckUrl = check.getDetails().get("inConfigNotInBucket").toString();
+        String expectedMetadataUrlValue = HexUtils.encodeString(countryAConfigUrl.toString());
+
         assertFalse(check.isHealthy());
+        assertTrue(metadataConfigHealthCheckUrl.contains(expectedMetadataUrlValue));
     }
 
     @Test
@@ -83,7 +89,12 @@ public class ReconciliationHealthCheckTest {
 
         HealthCheck.Result check = reconciliationHealthCheck.check();
 
+        String metadataBucketHealthCheckUrl = check.getDetails().get("inBucketNotInConfig").toString();
+        String expectedBucketMetadataUrlValue = BUCKET_URL_A;
+
         assertFalse(check.isHealthy());
+        assertTrue(metadataBucketHealthCheckUrl.contains(expectedBucketMetadataUrlValue));
+
     }
 
     @Test


### PR DESCRIPTION
- Reconciliation health check will show whether the config and the bucket
match with one another. I.E - If metadata is not in config but in bucket then show
as unhealthy.