### PR TITLE
EID-827: Remove bespoke gradle jar command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,33 @@ AWS_SECRET_ACCESS_KEY
 AWS_SESSION_TOKEN
 ```
 
-## Future Development - DropWizard Application
+## DropWizard Application
 
 The eIDAS metadata aggregator is currently undergoing transformation to run as a DropWizard application. This README file will be updated when the changes are completed.
+
+### Building and running
+
+To build for use run:
+```
+./gradlew clean build installDist
+```
+
+Then to run it:
+```
+./build/install/verify-eidas-metadata-aggregator/bin/verify-eidas-metadata-aggregator server configuration/metadata-aggregator.yml
+```
+
+The configuration file reads some environment variables. Depending on your environment you could also need to set, as an example:
+```
+export TRUST_ANCHOR_URI="https://verify-joint-metadata.cloudapps.digital/trust-anchor.jws"
+export TRUSTSTORE="../ida-hub-acceptance-tests/truststores/ida_truststore.ts"
+export LOG_PATH="/tmp"`cat ../ida-hub-acceptance-tests/configuration/test-rp-msa.yml | grep trustStorePassword | awk '{ print $2; }'`
+export HOURS_BETWEEN_EACH_RUN=1
+export ENVIRONMENT="joint"
+export AWS_REGION="eu-west-2"
+```
+
+To access the results of aggregations and reconciliation, in a browser visit http://localhost:51201/healthcheck.
 
 ## Support and responsible disclosure
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ The configuration file reads some environment variables. Depending on your envir
 ```
 export TRUST_ANCHOR_URI="https://verify-joint-metadata.cloudapps.digital/trust-anchor.jws"
 export TRUSTSTORE="../ida-hub-acceptance-tests/truststores/ida_truststore.ts"
-export LOG_PATH="/tmp"`cat ../ida-hub-acceptance-tests/configuration/test-rp-msa.yml | grep trustStorePassword | awk '{ print $2; }'`
+export LOG_PATH="/tmp"
+export TRUSTSTORE_PASSWORD=`cat ../ida-hub-acceptance-tests/configuration/test-rp-msa.yml | grep trustStorePassword | awk '{ print $2; }'`
 export HOURS_BETWEEN_EACH_RUN=1
 export ENVIRONMENT="joint"
 export AWS_REGION="eu-west-2"

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ mainClassName = 'uk.gov.ida.metadataaggregator.MetadataAggregatorApplication'
 ext {
     openSamlVersion = '3.3.0'
     saml_libs_version = "${openSamlVersion}-151"
+    ida_utils_version = "336"
     build_version = "${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
 }
 
@@ -53,7 +54,8 @@ dependencies {
             'org.slf4j:log4j-over-slf4j:1.7.12',
             'com.squarespace.jersey2-guice:jersey2-guice-impl:1.0.6',
             'com.hubspot.dropwizard:dropwizard-guicier:1.0.0.6',
-            'uk.gov.ida:common-utils:2.0.0-335',
+            "uk.gov.ida:common-utils:2.0.0-$ida_utils_version",
+            "uk.gov.ida:rest-utils:2.0.0-$ida_utils_version",
             "uk.gov.ida:saml-serializers:$saml_libs_version"
     )
 

--- a/build.gradle
+++ b/build.gradle
@@ -31,15 +31,6 @@ ext {
 group = "uk.gov.ida.eidas"
 version = "0.1-$build_version"
 
-jar {
-    from {
-        configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
-    }
-    manifest {
-        attributes 'Main-Class': mainClassName
-    }
-}
-
 sourceCompatibility = 1.8
 
 repositories {

--- a/configuration/metadata-aggregator.yml
+++ b/configuration/metadata-aggregator.yml
@@ -51,6 +51,6 @@ s3BucketName: ${S3_BUCKET_NAME}
 
 hoursBetweenEachRun: ${HOURS_BETWEEN_EACH_RUN}
 
-metadataSourcesFile: ${METADATA_SOURCES_FILE}
+environment: ${ENVIRONMENT}
 
 awsRegion: ${AWS_REGION}

--- a/configuration/metadata-aggregator.yml
+++ b/configuration/metadata-aggregator.yml
@@ -38,6 +38,9 @@ logging:
       facility: local2
       tag: metadata-aggregator
 
+serviceInfo:
+  name: metadata-aggregator
+
 trustAnchorUri: ${TRUST_ANCHOR_URI}
 trustStore:
   type: ${TRUSTSTORE_TYPE:-file}

--- a/src/main/java/uk/gov/ida/metadataaggregator/MetadataAggregatorApplication.java
+++ b/src/main/java/uk/gov/ida/metadataaggregator/MetadataAggregatorApplication.java
@@ -8,6 +8,7 @@ import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
+import uk.gov.ida.bundles.LoggingBundle;
 import uk.gov.ida.metadataaggregator.healthcheck.AggregationStatusHealthCheck;
 import uk.gov.ida.metadataaggregator.healthcheck.ReconciliationHealthCheck;
 import uk.gov.ida.metadataaggregator.managed.ScheduledMetadataAggregator;
@@ -37,6 +38,7 @@ public class MetadataAggregatorApplication extends Application<MetadataAggregato
                 .build();
 
         bootstrap.addBundle(guiceBundle);
+        bootstrap.addBundle(new LoggingBundle());
         bootstrap.setConfigurationSourceProvider(new SubstitutingSourceProvider(bootstrap.getConfigurationSourceProvider(), new EnvironmentVariableSubstitutor(false)));
     }
 

--- a/src/main/java/uk/gov/ida/metadataaggregator/MetadataAggregatorApplication.java
+++ b/src/main/java/uk/gov/ida/metadataaggregator/MetadataAggregatorApplication.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.util.StdDateFormat;
 import com.hubspot.dropwizard.guicier.GuiceBundle;
 import com.squarespace.jersey2.guice.JerseyGuiceUtils;
 import io.dropwizard.Application;
+import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
+import io.dropwizard.configuration.SubstitutingSourceProvider;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import uk.gov.ida.metadataaggregator.healthcheck.AggregationStatusHealthCheck;
@@ -35,6 +37,7 @@ public class MetadataAggregatorApplication extends Application<MetadataAggregato
                 .build();
 
         bootstrap.addBundle(guiceBundle);
+        bootstrap.setConfigurationSourceProvider(new SubstitutingSourceProvider(bootstrap.getConfigurationSourceProvider(), new EnvironmentVariableSubstitutor(false)));
     }
 
     @Override

--- a/src/main/java/uk/gov/ida/metadataaggregator/MetadataAggregatorConfiguration.java
+++ b/src/main/java/uk/gov/ida/metadataaggregator/MetadataAggregatorConfiguration.java
@@ -3,6 +3,8 @@ package uk.gov.ida.metadataaggregator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
+import uk.gov.ida.common.ServiceInfoConfiguration;
+import uk.gov.ida.configuration.ServiceNameConfiguration;
 import uk.gov.ida.saml.metadata.TrustStoreConfiguration;
 
 import javax.validation.Valid;
@@ -11,7 +13,12 @@ import java.net.URI;
 import java.security.KeyStore;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class MetadataAggregatorConfiguration extends Configuration {
+public class MetadataAggregatorConfiguration extends Configuration implements ServiceNameConfiguration {
+
+    @JsonProperty
+    @NotNull
+    @Valid
+    private ServiceInfoConfiguration serviceInfo;
 
     @Valid
     @NotNull
@@ -61,5 +68,10 @@ public class MetadataAggregatorConfiguration extends Configuration {
 
     public String getAwsRegion() {
         return awsRegion;
+    }
+
+    @Override
+    public String getServiceName() {
+        return serviceInfo.getName();
     }
 }

--- a/src/main/java/uk/gov/ida/metadataaggregator/MetadataAggregatorConfiguration.java
+++ b/src/main/java/uk/gov/ida/metadataaggregator/MetadataAggregatorConfiguration.java
@@ -26,6 +26,10 @@ public class MetadataAggregatorConfiguration extends Configuration implements Se
     private URI trustAnchorUri;
 
     @Valid
+    @JsonProperty
+    private String environment;
+
+    @Valid
     @NotNull
     @JsonProperty
     private TrustStoreConfiguration trustStore;
@@ -60,7 +64,9 @@ public class MetadataAggregatorConfiguration extends Configuration implements Se
         return s3BucketName;
     }
 
-    public String getMetadataSourcesFile() { return metadataSourcesFile; }
+    public String getEnvironment() {
+        return environment;
+    }
 
     public long getHoursBetweenEachRun() {
         return hoursBetweenEachRun;

--- a/src/main/java/uk/gov/ida/metadataaggregator/MetadataAggregatorModule.java
+++ b/src/main/java/uk/gov/ida/metadataaggregator/MetadataAggregatorModule.java
@@ -65,7 +65,7 @@ class MetadataAggregatorModule extends AbstractModule {
 
     @Provides
     public MetadataSourceConfigurationLoader getMetadataSourceConfigurationLoader(MetadataAggregatorConfiguration configuration) {
-        return new MetadataSourceConfigurationLoader(configuration.getMetadataSourcesFile());
+        return new MetadataSourceConfigurationLoader(configuration.getEnvironment());
     }
 
     @Provides

--- a/src/test/resources/apprule/metadata-aggregator.yml
+++ b/src/test/resources/apprule/metadata-aggregator.yml
@@ -37,4 +37,4 @@ s3BucketName: testS3Bucket
 
 hoursBetweenEachRun: 1
 
-metadataSourcesFile: joint
+environment: joint

--- a/src/test/resources/apprule/metadata-aggregator.yml
+++ b/src/test/resources/apprule/metadata-aggregator.yml
@@ -30,6 +30,9 @@ trustStore:
   store: ABCD
   password: 1234
 
+serviceInfo:
+  name: metadata-aggregator
+
 s3BucketName: testS3Bucket
 
 hoursBetweenEachRun: 1

--- a/startup-local.sh
+++ b/startup-local.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+export TRUST_ANCHOR_URI="https://verify-joint-metadata.cloudapps.digital/trust-anchor.jws"
+export TRUSTSTORE="../ida-hub-acceptance-tests/truststores/ida_truststore.ts"
+export LOG_PATH="/tmp"
+export TRUSTSTORE_PASSWORD=`cat ../ida-hub-acceptance-tests/configuration/test-rp-msa.yml | grep trustStorePassword | awk '{ print $2; }'`
+export HOURS_BETWEEN_EACH_RUN=1
+export ENVIRONMENT="joint"
+export AWS_REGION="eu-west-2"
+
+./gradlew clean build installDist
+
+./build/install/verify-eidas-metadata-aggregator/bin/verify-eidas-metadata-aggregator server configuration/metadata-aggregator.yml


### PR DESCRIPTION
Removing this because it overrides Gradle's default jar task.  When we leave it in,
it generates a jar file that can't actually run.  It complains it can't find the
main class.

Co-authored-by: Simon Worthington <simon.worthington@digital.cabinet-office.gov.uk>