### PR TITLE
BAU Remove Italy from integration

### DIFF
--- a/src/main/resources/integration/MetadataSourceConfiguration.json
+++ b/src/main/resources/integration/MetadataSourceConfiguration.json
@@ -4,7 +4,6 @@
     "Denmark metadata": "https://eidasservice.test.eid.digst.dk/Metadata",
     "Estonia metadata": "https://eidastest.eesti.ee/EidasNode/ServiceMetadata",
     "Germany metadata": "https://middleware.integration-mw-de.eidas.signin.service.gov.uk/eidas-middleware/Metadata",
-    "Italy metadata": "https://service.pre.eid.gov.it/EidasNode/ServiceMetadata",
     "Netherlands metadata": "https://acc-eidas.minez.nl/EidasNodeP/ServiceMetadata",
     "Spain metadata": "https://se-eidas.redsara.es/EidasNode/ServiceMetadata",
     "Stub Country metadata": "https://ida-stub-idp-integration.cloudapps.digital/stub-country/ServiceMetadata",


### PR DESCRIPTION
Italy's metadata endpoint is refusing to connect. This has broken the
metadata pipeline so we're removing it here. A card is being written to
find a better solution.