### PR TITLE
Revert "BAU Remove Italy from integration"

### DIFF
--- a/src/main/resources/integration/MetadataSourceConfiguration.json
+++ b/src/main/resources/integration/MetadataSourceConfiguration.json
@@ -4,6 +4,7 @@
     "Denmark metadata": "https://eidasservice.test.eid.digst.dk/Metadata",
     "Estonia metadata": "https://eidastest.eesti.ee/EidasNode/ServiceMetadata",
     "Germany metadata": "https://middleware.integration-mw-de.eidas.signin.service.gov.uk/eidas-middleware/Metadata",
+    "Italy metadata": "https://service.pre.eid.gov.it/EidasNode/ServiceMetadata",
     "Netherlands metadata": "https://acc-eidas.minez.nl/EidasNodeP/ServiceMetadata",
     "Spain metadata": "https://se-eidas.redsara.es/EidasNode/ServiceMetadata",
     "Stub Country metadata": "https://ida-stub-idp-integration.cloudapps.digital/stub-country/ServiceMetadata",


### PR DESCRIPTION
This reverts commit 8b201d2a0b9c24a43286fd91eb2ae50d199e3881.

Italy's metadata has come back so we can add them again.