### PR TITLE
AUTO-112: Update to use new Stub IDP in Staging and use latest version of SAML Libs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,8 @@ apply plugin: 'maven-publish'
 mainClassName = 'uk.gov.ida.metadataaggregator.MetadataAggregatorApplication'
 
 ext {
-    openSamlVersion = '3.3.0'
-    saml_libs_version = "${openSamlVersion}-151"
+    openSamlVersion = '3.4.2'
+    saml_libs_version = "${openSamlVersion}-201"
     ida_utils_version = "336"
     build_version = "${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
 }
@@ -50,19 +50,18 @@ dependencies {
     compile (
             'com.nimbusds:nimbus-jose-jwt:5.4',
             'com.amazonaws:aws-java-sdk-s3:1.11.277',
-            "uk.gov.ida:saml-metadata-bindings:$saml_libs_version",
+            "uk.gov.ida:saml-lib:$saml_libs_version",
             'org.slf4j:log4j-over-slf4j:1.7.12',
             'com.squarespace.jersey2-guice:jersey2-guice-impl:1.0.6',
             'com.hubspot.dropwizard:dropwizard-guicier:1.0.0.6',
             "uk.gov.ida:common-utils:2.0.0-$ida_utils_version",
-            "uk.gov.ida:rest-utils:2.0.0-$ida_utils_version",
-            "uk.gov.ida:saml-serializers:$saml_libs_version"
+            "uk.gov.ida:rest-utils:2.0.0-$ida_utils_version"
     )
 
     testCompile(
             'junit:junit:4.12',
             'org.mockito:mockito-core:2.23.4',
             'org.assertj:assertj-core:3.10.0',
-            "uk.gov.ida:saml-metadata-bindings-test:$saml_libs_version"
+            "uk.gov.ida:saml-test:$saml_libs_version"
     )
 }

--- a/src/main/resources/staging/MetadataSourceConfiguration.json
+++ b/src/main/resources/staging/MetadataSourceConfiguration.json
@@ -1,6 +1,6 @@
 {
   "metadataUrls": {
     "Germany metadata": "https://middleware.staging-mw-de.eidas.signin.service.gov.uk/eidas-middleware/Metadata",
-    "Stub Country metadata": "https://ida-stub-idp-staging.cloudapps.digital/stub-country/ServiceMetadata"
+    "Stub Country metadata": "https://stub-idp-staging.cloudapps.digital/stub-country/ServiceMetadata"
   }
 }


### PR DESCRIPTION
This pull request updates verify-eidas-metadata-aggregator to use new Stub IDP in staging environment and to use new latest version of SAML libraries.

Author: @adityapahuja